### PR TITLE
Begin a transition to a more modular build API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ name = "abs"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rayon",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
@@ -115,56 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,46 +155,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.14"
+name = "futures"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -451,15 +442,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -707,31 +689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,12 +755,6 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -871,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,7 +972,22 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ clap = "=3.0.0-beta.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11.3", features = ["blocking"] }
-rayon = "1.0"
 tokio = { version = "1.0", features = ["process", "macros"] }
+futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11.3", features = ["blocking"] }
 rayon = "1.0"
+tokio = { version = "1.0", features = ["process", "macros"] }

--- a/src/build.rs
+++ b/src/build.rs
@@ -605,9 +605,9 @@ impl<'a> BuildEnvironment<'a> {
         task::spawn(async move {
             while let Some(output) = rx.recv().await {
                 match output {
-                    CompilerOutput::Begun { first_line } => println!("{}", first_line),
-                    CompilerOutput::Error(error) => println!("{}", error),
-                    CompilerOutput::Warning(warning) => println!("{}", warning),
+                    CompilerOutput::Begun { first_line } => println!("\nBEGIN:\n{}\nEND\n", first_line),
+                    CompilerOutput::Error(error) => println!("\nBEGIN:\n{}\nEND\n", error),
+                    CompilerOutput::Warning(warning) => println!("\nBEGIN:\n{}\nEND\n", warning),
                 }
             }
         });

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -1,0 +1,109 @@
+// This intent behind this module is to define a prototype build interface that can later be
+// translated to C/C++ for builds.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+// use std::io::Error as IoError;
+// use std::fs;
+use tokio::process::Command;
+use std::process::Stdio;
+use tokio::io::{BufReader, AsyncBufReadExt};
+
+use crate::toolchain_paths::ToolchainPaths;
+use crate::Platform;
+
+// #[derive(Default)]
+// pub struct SrcPaths<PathStorage: Default> {
+//     pub directory_path: PathBuf,
+//     pub paths: PathStorage,
+//     pub children: Vec<SrcPaths<PathStorage>>,
+// }
+
+// fn scan_sources<PathStorage: Default>(root: impl Into<PathBuf>, visitor: impl FnMut(&Path, &mut PathStorage)) -> Result<SrcPaths<PathStorage>, IoError> {
+//     let root = root.into();
+//     let mut children = Vec::new();
+//     let mut paths = PathStorage::default();
+//     for entry in fs::read_dir(&root)? {
+//         let entry = entry?;
+//         let file_type = entry.file_type()?;
+//         if file_type.is_dir() {
+//             let child = scan_sources(entry.path(), visitor)?;
+//             children.push(child);
+//         } else if file_type.is_file() {
+//             visitor(entry.path(), &mut storage);
+//         } else {
+//             // TODO: handle this somehow maybe?
+//         }
+//         if entry.file_type()?.is_d
+//     }
+// }
+
+// struct HeaderAndCppPaths {
+//     headers: Vec<PathBuf>,
+//     srcs: Vec<PathBuf>,
+// }
+
+// fn scan_test() {
+//     scan_sources("my_path", |path, paths| )
+// }
+
+async fn run_cmd(name: impl AsRef<OsStr>, args: &[OsString], bin_paths: &[PathBuf]) {
+    let mut path = OsString::from("%PATH%");
+    for i in 0..bin_paths.len() {
+        path.push(";");
+        path.push(bin_paths[i].as_os_str());
+    }
+    let mut child = Command::new(name)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(args)
+        .env("PATH", path)
+        .spawn().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    
+    let stdout_reader = tokio::task::spawn(async {
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+        while let Some(line) = lines.next_line().await.unwrap() {
+            println!("stdout line: {}", line);
+        }
+    });
+
+    let stderr_reader = tokio::task::spawn(async {
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+        while let Some(line) = lines.next_line().await.unwrap() {
+            println!("stderr line: {}", line);
+        }
+    });
+
+    let (stdout, stderr) = tokio::join!(stdout_reader, stderr_reader);
+    stdout.unwrap();
+    stderr.unwrap();
+}
+
+async fn compile(toolchain_paths: &ToolchainPaths) {
+    let mut flags: Vec<OsString> = vec![
+        "/W3".into(),
+        "/Zi".into(),
+        "/EHsc".into(),
+        "/c".into(),
+        "/FS".into(),
+    ];
+    flags.push("/FoC:\\Users\\zachr\\work\\test\\test.obj".into());
+    flags.push("/FdC:\\Users\\zachr\\work\\test\\test.pdb".into());
+    flags.push("C:\\Users\\zachr\\work\\test\\test.cpp".into());
+    run_cmd("cl.exe", &flags, &toolchain_paths.bin_paths).await;
+}
+
+pub fn test() {
+    let paths = ToolchainPaths::find(Platform::Win64).unwrap();
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            compile(&paths).await;
+        })
+}

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -64,7 +64,7 @@ pub async fn run_cmd(name: impl AsRef<OsStr>, args: impl IntoIterator<Item=impl 
         .map(|code| code.success()).unwrap_or(false)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CompilerOutput {
     Begun { first_line: String },
     Warning(String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod build_manager;
 mod toolchain_paths;
 
 use proj_config::{ProjectConfig, OutputType, CxxOptions, Platform};
-use cmd_options::{CmdOptions, CompileMode, Subcommand, BuildOptions};
+use cmd_options::{CmdOptions, CompileMode, Subcommand, Target, BuildOptions};
 use build::BuildEnvironment;
 use toolchain_paths::ToolchainPaths;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use clap::Parser;
 mod build;
 mod cmd_options;
 mod proj_config;
+mod build_manager;
 mod toolchain_paths;
 
 use proj_config::{ProjectConfig, OutputType, CxxOptions, Platform};
@@ -53,6 +54,9 @@ pub fn canonicalize(p: impl AsRef<Path>) -> IoResult<PathBuf> {
 
 #[cfg(target_os = "windows")]
 fn main() {
+    build_manager::test();
+    return;
+
     use crate::cmd_options::Target;
 
     let options = CmdOptions::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,8 @@ pub fn canonicalize(p: impl AsRef<Path>) -> IoResult<PathBuf> {
 }
 
 #[cfg(target_os = "windows")]
-fn main() {
-    build_manager::test();
-    return;
-
+#[tokio::main]
+async fn main() {
     use crate::cmd_options::Target;
 
     let options = CmdOptions::parse();
@@ -358,8 +356,8 @@ void print_hello_world() {{
             }
             validate_dependencies(&mut projects, &mut link_libraries, &config.name, cxx_options, &config.name);
 
-            fn build_all<'a>(target: Platform, build_options: &BuildOptions, dependencies: impl IntoIterator<Item=&'a mut Project>, root_project: &mut Project, link_libraries: &[String]) -> (PathBuf, ToolchainPaths) {
-                fn build(target: Platform, build_options: &BuildOptions, config: &ProjectConfig, config_path: &Path) -> (Option<PathBuf>, ToolchainPaths) {
+            async fn build_all<'a>(target: Platform, build_options: &BuildOptions, dependencies: impl IntoIterator<Item=&'a mut Project>, root_project: &mut Project, link_libraries: &[String]) -> (PathBuf, ToolchainPaths) {
+                async fn build(target: Platform, build_options: &BuildOptions, config: &ProjectConfig, config_path: &Path) -> (Option<PathBuf>, ToolchainPaths) {
                     let mode = match build_options.compile_mode {
                         CompileMode::Debug => "debug",
                         CompileMode::Release => "release",
@@ -381,7 +379,7 @@ void print_hello_world() {{
                         &artifact_path,
                     ).unwrap();
         
-                    match env.build() {
+                    match env.build().await {
                         Ok(produced_artifact) => {
                             println!("Build succeeded.");
                             let artifact_path = if produced_artifact {
@@ -398,7 +396,7 @@ void print_hello_world() {{
                 let mut link_libraries = Vec::from(link_libraries);
                 for project in dependencies {
                     project.config.adapt_to_workspace(&root_project.config);
-                    let (artifact_path, _) = build(target, build_options, &project.config, &project.config_path);
+                    let (artifact_path, _) = build(target, build_options, &project.config, &project.config_path).await;
                     if let Some(mut artifact_path) = artifact_path {
                         artifact_path.push(format!("{}.lib", project.config.name));
                         link_libraries.push(artifact_path.as_os_str().to_string_lossy().into());
@@ -407,7 +405,7 @@ void print_hello_world() {{
                     println!();
                 }
                 root_project.config.link_libraries = link_libraries;
-                let (artifact_path, toolchain_paths) = build(target, build_options, &root_project.config, &root_project.config_path);
+                let (artifact_path, toolchain_paths) = build(target, build_options, &root_project.config, &root_project.config_path).await;
                 (artifact_path.unwrap(), toolchain_paths)
             }
             let mut root_project = projects.remove(&config.name).unwrap();
@@ -427,7 +425,7 @@ void print_hello_world() {{
                         fail_immediate!("Target `all` is not valid for `{}` subcommand. Please use the `build` subcommand instead.", sub_command_name);
                     } else {
                         for &supported_target in &config.supported_targets {
-                            build_all(supported_target, build_options, &mut dependencies, &mut root_project, &link_libraries);
+                            build_all(supported_target, build_options, &mut dependencies, &mut root_project, &link_libraries).await;
                         }
                         return;
                     }
@@ -465,7 +463,7 @@ void print_hello_world() {{
                             }
                         }
                     }
-                    let (artifact_path, toolchain_paths) = build_all(target, build_options, &mut dependencies, &mut root_project, &link_libraries);
+                    let (artifact_path, toolchain_paths) = build_all(target, build_options, &mut dependencies, &mut root_project, &link_libraries).await;
                     (config, artifact_path, toolchain_paths)
                 },
                 Target::Platform(target) => {
@@ -482,7 +480,7 @@ void print_hello_world() {{
                         fail_immediate!("`{}` subcommand cannot proceed because your host platform, {:?}, is not compatible with the supplied target {:?}. Please use the `build` subcommand instead.", sub_command_name, host, target);
                     }
 
-                    let (artifact_path, toolchain_paths) = build_all(target, build_options, &mut dependencies, &mut root_project, &link_libraries);
+                    let (artifact_path, toolchain_paths) = build_all(target, build_options, &mut dependencies, &mut root_project, &link_libraries).await;
                     (config, artifact_path, toolchain_paths)
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,6 @@ pub fn canonicalize(p: impl AsRef<Path>) -> IoResult<PathBuf> {
 #[cfg(target_os = "windows")]
 #[tokio::main]
 async fn main() {
-    use crate::cmd_options::Target;
-
     let options = CmdOptions::parse();
     macro_rules! _task_failed {
         () => {


### PR DESCRIPTION
I'm trying to gradually make my build API more modular and flexible, to make it easier to add features, and also pave the way for custom build scripts written in C/++. I'm still in the early stages of this change, but there are already a few added bonuses in this PR:
- Started parsing MSVC compiler output (which I'm not entirely convinced is a good idea, but that's besides the point)
- Fixed the race condition in compiler output that originated when I first implemented parallel compilation.
- Started caching and re-displaying warnings across builds
- Started deduplicating warnings and errors, to reduce noise as a result of a problem in a header